### PR TITLE
Archive in multiple jobs

### DIFF
--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -16,7 +16,7 @@ jobs:
       GH_TOKEN: ${{ secrets.NFLVERSE_GH_TOKEN }}
     steps:
       - name: Create release with gh
-        run: gh release create archive-$(date '+%Y-%m-%d') -R nflverse/nflverse-data-archives
+        run: gh release create archive-$(date '+%Y-%m-%d') -R nflverse/nflverse-data-archives || true
     
   archive_nflversedata:
     needs: create_release

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -3,7 +3,7 @@ on:
     # At 15:15 on Thursdays every week in Sep - Jan
     - cron: '15 15 * 9-12,1 4'
     # At 15:15 on the 15th day of each month from Feb -> Aug
-    - cron: '15 15 15 2-8 *'    
+    - cron: '15 15 15 2-8 *'
   workflow_dispatch:
 
 name: archive_nflversedata
@@ -19,13 +19,33 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-20.04,   r: 'release'}
-
+        tag:
+          - combine
+          - contracts
+          - depth_charts
+          - draft_picks
+          - espn_data
+          - ftn_charting
+          - injuries
+          - misc
+          - nextgen_stats
+          - officials
+          - pbp
+          - pbp_participation
+          - pfr_advstats
+          - player_stats
+          - players
+          - players_components
+          - rosters
+          - snap_counts
+          # - test
+          - weekly_rosters
     env:
       GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -42,4 +62,7 @@ jobs:
             nflverse/nflreadr
 
       - name: Archive all nflverse data
-        run: Rscript -e 'source("dev/run_archive.R")'
+        run: |
+          Sys.setenv("NFLVERSE_ARCHIVE_TAG" = ${{ matrix.tag }})
+          source("dev/run_archive.R")
+        shell: Rscript {0}

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -9,10 +9,10 @@ on:
 name: archive_nflversedata
 
 jobs:
-  update_snap_counts:
+  archive_nflversedata:
     runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    name: ${{ matrix.tag }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -14,13 +14,14 @@ jobs:
     name: create_release
     env:
       GH_TOKEN: ${{ secrets.NFLVERSE_GH_TOKEN }}
+    outputs:
+      releases: ${{ steps.query_releases.outputs.releases }}
     steps:
       - name: Create release with gh
         run: gh release create archive-$(date '+%Y-%m-%d') -R nflverse/nflverse-data-archives || true
-
-      # - name: Query nflverse-data release tags
-      #   run: gh release list --json tagName -R nflverse/nflverse-data || true
-
+      - id: query_releases
+        run: echo "releases=$(gh release list -R nflverse/nflverse-data --exclude-drafts --json tagName --jq '[.[].tagName]')" > $GITHUB_OUTPUT
+  
   archive_nflversedata:
     needs: create_release
     runs-on: ${{ matrix.config.os }}
@@ -30,27 +31,7 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-22.04,   r: 'release'}
-        tag:
-          - combine
-          - contracts
-          - depth_charts
-          - draft_picks
-          - espn_data
-          - ftn_charting
-          - injuries
-          - misc
-          - nextgen_stats
-          - officials
-          - pbp
-          - pbp_participation
-          - pfr_advstats
-          - player_stats
-          - players
-          - players_components
-          - rosters
-          - snap_counts
-          # - test
-          - weekly_rosters
+        tag: ${{ fromJson(needs.create_release.outputs.releases) }}
     env:
       GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -63,5 +63,4 @@ jobs:
             nflverse/nflreadr
 
       - name: Archive all nflverse data
-        run: dev/run_archive.R
-        shell: Rscript {0}
+        run: Rscript -e "source('dev/run_archive.R')"

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -12,12 +12,15 @@ jobs:
   create_release:
     runs-on: ubuntu-latest
     name: create_release
-    env: 
+    env:
       GH_TOKEN: ${{ secrets.NFLVERSE_GH_TOKEN }}
     steps:
       - name: Create release with gh
         run: gh release create archive-$(date '+%Y-%m-%d') -R nflverse/nflverse-data-archives || true
-    
+
+      # - name: Query nflverse-data release tags
+      #   run: gh release list --json tagName -R nflverse/nflverse-data || true
+
   archive_nflversedata:
     needs: create_release
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -62,5 +62,5 @@ jobs:
             r-lib/pkgload
             nflverse/nflreadr
 
-      - name: Archive all nflverse data
+      - name: Archive nflverse release
         run: Rscript -e "source('dev/run_archive.R')"

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -43,6 +43,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      NFLVERSE_ARCHIVE_TAG: ${{ matrix.tag }}
 
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +63,5 @@ jobs:
             nflverse/nflreadr
 
       - name: Archive all nflverse data
-        run: |
-          Sys.setenv("NFLVERSE_ARCHIVE_TAG" = ${{ matrix.tag }})
-          source("dev/run_archive.R")
+        run: dev/run_archive.R
         shell: Rscript {0}

--- a/.github/workflows/run_archive.yaml
+++ b/.github/workflows/run_archive.yaml
@@ -9,16 +9,24 @@ on:
 name: archive_nflversedata
 
 jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    name: create_release
+    env: 
+      GH_TOKEN: ${{ secrets.NFLVERSE_GH_TOKEN }}
+    steps:
+      - name: Create release with gh
+        run: gh release create archive-$(date '+%Y-%m-%d') -R nflverse/nflverse-data-archives
+    
   archive_nflversedata:
+    needs: create_release
     runs-on: ${{ matrix.config.os }}
-
     name: ${{ matrix.tag }}
-
     strategy:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-20.04,   r: 'release'}
+          - {os: ubuntu-22.04,   r: 'release'}
         tag:
           - combine
           - contracts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,14 @@
+on:
+  workflow_dispatch:
+
+name: test
+
+jobs:
+  create_release:
+    runs-on: ubuntu-22.04
+    name: create_release
+    env:
+      GITHUB_PAT: ${{ secrets.NFLVERSE_GH_TOKEN }}
+    steps:
+      - name: Create Release with gh
+        run: gh release create archive-$(date '+%Y-%m-%d') -R nflverse/nflverse-data-archives

--- a/R/archive.R
+++ b/R/archive.R
@@ -6,14 +6,18 @@
 nflverse_archive <- function(release_name){
   cli::cli_alert_info("Archiving {release_name}")
   temp_dir <- tempdir()
-  nflreadr::nflverse_download(!!release_name,folder_path = temp_dir, file_type = "rds")
+  nflreadr::nflverse_download(!!release_name, folder_path = temp_dir, file_type = "rds")
 
-  try({
-    piggyback::pb_new_release(
-      repo = "nflverse/nflverse-data-archives",
-      tag = glue::glue("archive-{as.character(Sys.Date())}"))
-  },
-  silent = TRUE)
+  release_tag <- glue::glue("archive-{as.character(Sys.Date())}")
+  if (!release_tag %in% piggyback::pb_releases("nflverse/nflverse-data-archives")$release_name) {
+      
+    try({
+      piggyback::pb_new_release(
+        repo = "nflverse/nflverse-data-archives",
+        tag = glue::glue("archive-{as.character(Sys.Date())}"))
+    },
+    silent = TRUE)
+  }
 
   file_list <- list.files(file.path(temp_dir,release_name))
 
@@ -21,6 +25,7 @@ nflverse_archive <- function(release_name){
     file.path(temp_dir,release_name,file_list),
     file.path(temp_dir,release_name, paste0(release_name,"_",file_list))
   )
+  
   memoise::forget(piggyback::pb_releases)
   memoise::forget(piggyback:::pb_info)
   Sys.sleep(5)
@@ -28,7 +33,7 @@ nflverse_archive <- function(release_name){
   piggyback::pb_upload(
     file = list.files(file.path(temp_dir,release_name),full.names = TRUE),
     repo = "nflverse/nflverse-data-archives",
-    tag = glue::glue("archive-{as.character(Sys.Date())}")
+    tag = release_tag
   )
 
   cli::cli_alert_success("Successfully archived {release_name}")

--- a/dev/run_archive.R
+++ b/dev/run_archive.R
@@ -1,3 +1,13 @@
 pkgload::load_all()
-piggyback::pb_releases("nflverse/nflverse-data")$tag_name |>
-  lapply(nflversedata::nflverse_archive)
+
+tag <- Sys.getenv("NFLVERSE_ARCHIVE_TAG", unset = NA_character_)
+
+if (is.na(tag)){
+  cli::cli_abort("Can't find the release tag to archive!")
+} else {
+  nflversedata::nflverse_archive(release_name = tag)
+}
+
+# Create tag list for workflow file
+# all_tags <- piggyback::pb_releases("nflverse/nflverse-data")$tag_name
+# cli::cli_bullets(paste("-", sort(all_tags)))


### PR DESCRIPTION
Trying to set up muiltiple jobs by adding the release tags to archive into an array in the matrix setup

Needs test runs to see if it works. 

Main problem here: new releases need to be added manually to the array, otherwise they won't be archived