### PR TITLE
add release upload wrappers using gh cli

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,4 +28,4 @@ Imports:
     rlang
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: nflversedata
 Title: nflverse data storage functions
-Version: 0.0.10
+Version: 0.0.11
 Authors@R: 
     person("Tan", "Ho", , "tan@tanho.ca", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-8388-5155"))

--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -48,7 +48,9 @@ gh_cli_release_upload <- function(files,
     if(isTRUE(overwrite)) "--clobber" else ""
   )
   # Start shell command
-  cli::cli_progress_step("Start upload of {cli::no(length(files))} file{?s}")
+  cli::cli_progress_step("Start upload of {cli::no(length(files))} file{?s} to \\
+                         {.url {paste0('https://github.com/', repo, '/releases')}} \\
+                         @ {.field {tag}}")
 
   # This command will error if any error occurs.
   shell(cli_command, mustWork = TRUE)

--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -54,7 +54,7 @@ gh_cli_release_upload <- function(files,
                          @ {.field {tag}}")
 
   # This command will error if any error occurs.
-  shell(cli_command, mustWork = TRUE)
+  system(cli_command, intern = TRUE)
 
   cli::cli_progress_done()
 

--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -22,9 +22,19 @@ gh_cli_release_upload <- function(files,
 
   # validate file paths
   file_available <- file.exists(files)
+
+  # if files are missing, warn the user and update the files vector to keep
+  # valid file paths only. If there are no valid file paths, exit the function.
   if ( !all(file_available) ){
-    cli::cli_abort("The following file{?s} {?is/are} missing: {.path {files[!file_available]}}")
+    cli::cli_alert_warning("The following file{?s} {?is/are} missing: {.path {files[!file_available]}}")
+
+    if (all(file_available == FALSE)){
+      cli::cli_alert_warning("There's nothing left to upload. Exiting!")
+      return(invisible(FALSE))
+    }
   }
+  # keep valid file paths
+  files <- files[file_available]
 
   # Make sure the gh cli is available
   if ( !gh_cli_available() ) return(invisible(FALSE))

--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -1,0 +1,50 @@
+# See cli manual at https://cli.github.com/manual/
+
+# This functions tries the gh command in a terminal. If it errors, the gh cli
+# isn't available on the machine or at least not on the PATH variable
+gh_cli_available <- function(){
+  gh_test <- try(system2("gh", stderr = TRUE, stdout = FALSE), silent = TRUE)
+
+  if ( inherits(gh_test, "try-error") ){
+    cli::cli_alert_warning("The gh cli is not available on your machine!")
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
+}
+
+gh_cli_release_upload <- function(files,
+                                  tag,
+                                  ...,
+                                  repo = "nflverse/nflverse-data",
+                                  overwrite = TRUE){
+  # see https://cli.github.com/manual/gh_release_upload
+
+  # validate file paths
+  file_available <- file.exists(files)
+  if ( !all(file_available) ){
+    cli::cli_abort("The following file{?s} {?is/are} missing: {.path {files[!file_available]}}")
+  }
+
+  # Make sure the gh cli is available
+  if ( !gh_cli_available() ) return(invisible(FALSE))
+
+  # create command for the shell
+  cli_command <- paste(
+    "gh release upload",
+    tag,
+    paste(files, collapse = " "),
+    "-R", repo,
+    if(isTRUE(overwrite)) "--clobber" else ""
+  )
+  # Start shell command
+  cli::cli_progress_step("Start upload of {cli::no(length(files))} file{?s}")
+
+  # This command will error if any error occurs.
+  shell(cli_command, mustWork = TRUE)
+
+  cli::cli_progress_done()
+
+  invisible(TRUE)
+}
+

--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -6,11 +6,12 @@ gh_cli_available <- function(){
   gh_test <- try(system2("gh", stderr = TRUE, stdout = FALSE), silent = TRUE)
 
   if ( inherits(gh_test, "try-error") ){
-    cli::cli_alert_warning("The gh cli is not available on your machine!")
-    return(FALSE)
-  } else {
-    return(TRUE)
+    cli::cli_abort("The Github Command Line Interface is not available on your machine! \\
+                   Please visit {.url https://github.com/cli/cli#installation} \\
+                   for install instructions.")
   }
+
+  invisible(TRUE)
 }
 
 gh_cli_release_upload <- function(files,

--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -38,7 +38,7 @@ gh_cli_release_upload <- function(files,
   files <- files[file_available]
 
   # Make sure the gh cli is available
-  if ( !gh_cli_available() ) return(invisible(FALSE))
+  gh_cli_available()
 
   # create command for the shell
   cli_command <- paste(

--- a/R/upload.R
+++ b/R/upload.R
@@ -4,6 +4,7 @@
 #' @param tag release name
 #' @param ... currently not used
 #' @param repo repository to upload to, default: `"nflverse/nflverse-data"`
+#' @param overwrite If `TRUE` (the default) existing files will be overwritten
 #'
 #' @export
 nflverse_upload <- function(files, tag, ..., repo = "nflverse/nflverse-data", overwrite = TRUE){

--- a/R/upload.R
+++ b/R/upload.R
@@ -9,7 +9,7 @@
 #' @export
 nflverse_upload <- function(files, tag, ..., repo = "nflverse/nflverse-data", overwrite = TRUE){
   # create timestamp_files in a temp folder
-  timestamp_files <- path_to_timestamp_files()
+  timestamp_files <- create_timestamp_file()
 
   # append timestamp files to the actual files to upload
   # timestamp will be right BEFORE the upload begins instead of afterwards
@@ -19,7 +19,7 @@ nflverse_upload <- function(files, tag, ..., repo = "nflverse/nflverse-data", ov
   gh_cli_release_upload(files = files, tag = tag, repo = repo, overwrite = overwrite)
 }
 
-path_to_timestamp_files <- function(){
+create_timestamp_file <- function(){
   temp_dir <- tempdir(check = TRUE)
 
   update_time <- format(Sys.time(), tz = "America/Toronto", usetz = TRUE)

--- a/R/upload.R
+++ b/R/upload.R
@@ -2,19 +2,23 @@
 #'
 #' @param files vector of filepaths to upload
 #' @param tag release name
-#' @param ... other args passed to `piggyback::pb_upload()`
+#' @param ... currently not used
 #' @param repo repository to upload to, default: `"nflverse/nflverse-data"`
 #'
 #' @export
-nflverse_upload <- function(files, tag, repo = "nflverse/nflverse-data", ...){
-  cli::cli_alert("Uploading {length(files)} files!")
-  # upload files
-  piggyback::pb_upload(files, repo = repo, tag = tag, ...)
-  update_release_timestamp(tag, repo = repo)
-  cli::cli_alert("Uploaded {length(files)} to {repo} @ {tag} on {Sys.time()}")
+nflverse_upload <- function(files, tag, ..., repo = "nflverse/nflverse-data", overwrite = TRUE){
+  # create timestamp_files in a temp folder
+  timestamp_files <- path_to_timestamp_files()
+
+  # append timestamp files to the actual files to upload
+  # timestamp will be right BEFORE the upload begins instead of afterwards
+  # but it won't be released at all if the upload breaks
+  files <- c(files, timestamp_files)
+
+  gh_cli_release_upload(files = files, tag = tag, repo = repo, overwrite = overwrite)
 }
 
-update_release_timestamp <- function(tag, repo = "nflverse/nflverse-data"){
+path_to_timestamp_files <- function(){
   temp_dir <- tempdir(check = TRUE)
 
   update_time <- format(Sys.time(), tz = "America/Toronto", usetz = TRUE)
@@ -24,10 +28,9 @@ update_release_timestamp <- function(tag, repo = "nflverse/nflverse-data"){
     jsonlite::toJSON(auto_unbox = TRUE) |>
     writeLines(file.path(temp_dir,"timestamp.json"))
 
-  piggyback::pb_upload(file.path(temp_dir,"timestamp.txt"), repo = repo, tag = tag, overwrite = TRUE)
-  piggyback::pb_upload(file.path(temp_dir,"timestamp.json"), repo = repo, tag = tag, overwrite = TRUE)
+  timestamp_files <- file.path(temp_dir, c("timestamp.txt", "timestamp.json"))
 
-  invisible(NULL)
+  timestamp_files
 }
 
 #' Save files to nflverse release

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,11 +16,5 @@
       value = purrr::insistently(nflverse_upload, rate = retry_rate, quiet = quiet),
       envir = rlang::ns_env("nflversedata")
     )
-
-    assign(
-      x = "update_release_timestamp",
-      value = purrr::insistently(update_release_timestamp, rate = retry_rate, quiet = quiet),
-      envir = rlang::ns_env("nflversedata")
-    )
   }
 }

--- a/man/nflverse_upload.Rd
+++ b/man/nflverse_upload.Rd
@@ -7,13 +7,15 @@
 nflverse_upload(...)
 }
 \arguments{
-\item{...}{other args passed to \code{piggyback::pb_upload()}}
+\item{...}{currently not used}
 
 \item{files}{vector of filepaths to upload}
 
 \item{tag}{release name}
 
 \item{repo}{repository to upload to, default: \code{"nflverse/nflverse-data"}}
+
+\item{overwrite}{If \code{TRUE} (the default) existing files will be overwritten}
 }
 \description{
 Upload to nflverse release


### PR DESCRIPTION
This pr adds code to upload data to releases using the gh cli as an alternative piggyback