### PR TITLE
Catch warnings and error on warnings

### DIFF
--- a/R/gh_cli.R
+++ b/R/gh_cli.R
@@ -53,8 +53,17 @@ gh_cli_release_upload <- function(files,
                          {.url {paste0('https://github.com/', repo, '/releases')}} \\
                          @ {.field {tag}}")
 
-  # This command will error if any error occurs.
-  system(cli_command, intern = TRUE)
+  # This command will error regularly on R error and also errors on warnings
+  # because some failures raise a warning only and we want workflows to fail
+  # if somethings didn't work
+  out <- purrr::quietly(system)(cli_command, intern = TRUE)
+  if (length(out$warnings)) {
+    cli::cli_abort(
+      "The GitHub cli errored with the following message: {.val {out$result}}. \\
+     Here is the R message: {.val {out$warnings}}",
+      call = NULL
+    )
+  }
 
   cli::cli_progress_done()
 


### PR DESCRIPTION
The system call errors on stuff like missing gh cli but not if something inside the gh cli goes wrong, e.g. lost internet connection or incorrect tag name. In these cases, system just throws a warning message and our workflows don't fail. 

It's better to throw an error in these cases because we want to be altered with failing workflows. That's why I catch warnings with purrr::quietly and error if a warning has been thrown. The message returns both the R warning and the gh cli message.