### PR TITLE
default to printing error messages

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,7 +3,7 @@
     pause_base <- Sys.getenv("NFLVERSE.UPLOAD.PAUSE_BASE", 0.05) |> as.numeric()
     pause_min <- Sys.getenv("NFLVERSE.UPLOAD.PAUSE_MIN", 1) |> as.numeric()
     max_times <- Sys.getenv("NFLVERSE.UPLOAD.MAX_TIMES", 10) |> as.numeric()
-    quiet <- Sys.getenv("NFLVERSE.UPLOAD.QUIET", TRUE) |> as.logical()
+    quiet <- Sys.getenv("NFLVERSE.UPLOAD.QUIET", "false") |> as.logical()
 
     retry_rate <- purrr::rate_backoff(
       pause_base = pause_base,


### PR DESCRIPTION
because we use it mainly in CI and need to know what's going on